### PR TITLE
Fix: Report type imports for explicitly prohibited dependencies (default: devDependencies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 1
 
+### v1.1.1
+
+- Fix for the `development` option:
+  - Default value changed to `typeOnly` (no breaking changes);
+  - The `false` now prohibits the corresponding category of dependencies.
+
 ### v1.1.0
 
 - New config option `development` (disabled by default) for handling `devDependencies`.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ The import syntax also matters: regular `import` or `import type` (excluded from
 import { createServer } from "express-zod-api"; // OK
 import { join } from "node:fs"; // OK
 import { helper } from "./tools"; // OK
-import { factory } from "typescript"; // Error: Importing typescript is not allowed.
+import { factory } from "typescript"; // Error: Only 'import type' syntax is allowed for typescript.
 import { format } from "prettier"; // Error: Only 'import type' syntax is allowed for prettier.
+import fancyFn from "unlisted-module"; // Error: Importing unlisted-module is not allowed.
 ```
 
 ## Relationships and differences
@@ -145,7 +146,7 @@ development:
   type:
     - boolean
     - "typeOnly"
-  default: false
+  default: "typeOnly"
 
 typeOnly:
   description: Extra packages to allow type only imports

--- a/src/rule.spec.ts
+++ b/src/rule.spec.ts
@@ -123,20 +123,22 @@ tester.run("dependencies", rule, {
     {
       name: "type importing of explicitly prohibited dependency",
       code: `import type {} from "typescript"`,
-      before: makeBefore({ devDependencies: { typescript: "" } }), // dev is false by default
+      options: [{ development: false }],
+      before: makeBefore({ devDependencies: { typescript: "" } }),
       errors: [{ messageId: "prohibited", data: { name: "typescript" } }],
     },
     {
       name: "demo",
-      code: `import {factory} from "typescript"; import {format} from "prettier";`,
+      code: `import {factory} from "typescript"; import {format} from "prettier"; import fancyFn from "unlisted-module"`,
       before: makeBefore({
         devDependencies: { typescript: "^5" },
         peerDependencies: { prettier: "^3" },
         peerDependenciesMeta: { prettier: { optional: true } },
       }),
       errors: [
-        { messageId: "prohibited", data: { name: "typescript" } },
+        { messageId: "typeOnly", data: { name: "typescript" } },
         { messageId: "typeOnly", data: { name: "prettier" } },
+        { messageId: "prohibited", data: { name: "unlisted-module" } },
       ],
     },
   ],

--- a/src/rule.spec.ts
+++ b/src/rule.spec.ts
@@ -121,6 +121,12 @@ tester.run("dependencies", rule, {
       errors: [{ messageId: "prohibited", data: { name: "node:fs" } }],
     },
     {
+      name: "type importing of explicitly prohibited dependency",
+      code: `import type {} from "typescript"`,
+      before: makeBefore({ devDependencies: { typescript: "" } }), // dev is false by default
+      errors: [{ messageId: "prohibited", data: { name: "typescript" } }],
+    },
+    {
       name: "demo",
       code: `import {factory} from "typescript"; import {format} from "prettier";`,
       before: makeBefore({

--- a/src/rule.spec.ts
+++ b/src/rule.spec.ts
@@ -77,9 +77,8 @@ tester.run("dependencies", rule, {
       before: makeBefore({}),
     },
     {
-      name: "type import of accordingly enabled devDependency",
+      name: "type import of devDependency",
       code: `import type {} from "eslint"`,
-      options: [{ development: "typeOnly" }],
       before: makeBefore({ devDependencies: { eslint: "" } }),
     },
   ],

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -56,7 +56,11 @@ export const rule = ESLintUtils.RuleCreator.withoutDocs({
         values(mapObjIndexed((v, k) => (v === value ? sources[k] : []), rest)),
       );
 
-    const [allowed, limited] = [true, "typeOnly" as const].map(take);
+    const [allowed, prohibited, limited] = [
+      true,
+      false,
+      "typeOnly" as const,
+    ].map(take);
     limited.push(...typeOnly);
 
     return {
@@ -64,7 +68,7 @@ export const rule = ESLintUtils.RuleCreator.withoutDocs({
         if (!isIgnored(source.value)) {
           const name = getName(source.value);
           if (!allowed.includes(name)) {
-            if (importKind !== "type") {
+            if (importKind !== "type" || prohibited.includes(name)) {
               ctx.report({
                 node: source,
                 data: { name },

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -11,7 +11,7 @@ const messages = {
 const defaults: Options = {
   production: true,
   requiredPeers: true,
-  development: false,
+  development: "typeOnly",
   optionalPeers: "typeOnly",
 };
 


### PR DESCRIPTION
`false` should mean prohibited even for type imports (dev dependencies by default)